### PR TITLE
chore: Add requirements.txt for backend

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,9 @@
+asgiref==3.9.1
+Django==5.2.4
+django-cors-headers==4.7.0
+djangorestframework==3.16.0
+greenlet==3.2.3
+playwright==1.54.0
+pyee==13.0.0
+sqlparse==0.5.3
+typing_extensions==4.14.1


### PR DESCRIPTION
This commit adds a `requirements.txt` file to the `backend` directory. The file was generated using `pip freeze` and contains the list of all Python dependencies required to run the Django project, ensuring a reproducible environment.